### PR TITLE
Hw2

### DIFF
--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -167,8 +167,6 @@ $(\iota_j\circ\iota_k^{-1})(w)=\Big(\tfrac{w_0}{w_j},\ldots,\tfrac{w_{j-1}}{w_j}
 - If $j>k$, then $z_j=w_{j-1}$ and
 $(\iota_j\circ\iota_k^{-1})(w)=\Big(\tfrac{w_0}{w_{j-1}},\ldots,\tfrac{w_{k-1}}{w_{j-1}},\tfrac{1}{w_{j-1}},\tfrac{w_k}{w_{j-1}},\ldots,\tfrac{w_{j-2}}{w_{j-1}},\tfrac{w_j}{w_{j-1}},\ldots,\tfrac{w_{n-1}}{w_{j-1}}\Big)$.
 
-In each case the denominator is nonzero on $U_j\cap U_k$, so these maps are rational holomorphic functions.
-
-Thus $`\{\iota_k\}`$ defines the default smooth (indeed complex) structure on $\mathbb{CP}^n$, making it a $2n$-dimensional smooth manifold.
+In each case the denominator is nonzero on $U_j\cap U_k$, so these maps are smooth making $\mathbb{CP}^n$ a $2n$-dimensional smooth manifold.
 
 Compactness: consider the Hopf fibration $\pi:S^{2n+1}\subset\mathbb{C}^{n+1}\to\mathbb{CP}^n$, $\pi(z)=[z]$. The fiber is $S^1$, the map is continuous and surjective, and $S^{2n+1}$ is compact. Hence $\mathbb{CP}^n\cong S^{2n+1}/S^1$ is compact (and Hausdorff). Therefore $\mathbb{CP}^n$ is a compact smooth manifold.

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -169,4 +169,4 @@ $(\iota_j\circ\iota_k^{-1})(w)=\Big(\tfrac{w_0}{w_{j-1}},\ldots,\tfrac{w_{k-1}}{
 
 In each case the denominator is nonzero on $U_j\cap U_k$, so these maps are smooth making $\mathbb{CP}^n$ a $2n$-dimensional smooth manifold.
 
-Compactness: consider the Hopf fibration $\pi:S^{2n+1}\subset\mathbb{C}^{n+1}\to\mathbb{CP}^n$, $\pi(z)=[z]$. The fiber is $S^1$, the map is continuous and surjective, and $S^{2n+1}$ is compact. Hence $\mathbb{CP}^n\cong S^{2n+1}/S^1$ is compact (and Hausdorff). Therefore $\mathbb{CP}^n$ is a compact smooth manifold.
+Compactness: the map $\pi:S^{2n+1}\to\mathbb{CP}^n$, $\pi(z)=[z]$ is continuous and surjective, and $S^{2n+1}$ is compact. Hence $\mathbb{CP}^n\cong S^{2n+1}/S^1$ is compact.

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -157,11 +157,9 @@ $\iota_k:U_k\to\mathbb{C}^n,$
 
 $\iota_k([z])=(z_0/z_k,\ldots,z_{k-1}/z_k,z_{k+1}/z_k,\ldots,z_n/z_k).$
 
-Each $\iota_k$ is a homeomorphism with inverse
+Each $\iota_k:U_k\to\mathbb C^n$ is a homeomorphism with inverse
 
 $\iota_k^{-1}(w_0,\ldots,w_{n-1})=[w_0:\cdots:w_{k-1}:1:w_k:\cdots:w_{n-1}],$
-
-so $\{(U_k,\iota_k)\}_{k=0}^n$ is an atlas with model space $\mathbb{C}^n\cong\mathbb{R}^{2n}$.
 
 On overlaps $U_j\cap U_k$ the transition maps are holomorphic (hence smooth). Writing $w=(w_0,\ldots,w_{n-1})=\iota_k([z])$:
 - If $j<k$, then $z_j=w_j$ and

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -32,6 +32,22 @@ Write down (with proof) a smooth structure on the Möbius strip.
 
 Proof
 
+The Möbius strip is the quotient space of the rectangle $[0,1] \times [-1,1]$ by the equivalence relation that identifies the points $(0,y)$ and $(1,-y)$ for all $y \in [-1,1]$.
+
+To define a smooth structure on the Möbius strip, we can use the following charts:
+
+1. **Chart 1**: Define $U_1 = (0,1) \times (-1,1)$ and the chart map $\phi_1: U_1 \to \mathbb{R}^2$ by $\phi_1(x,y) = (x,y)$. This chart covers the interior of the rectangle and is clearly a homeomorphism onto its image.
+2. **Chart 2**: Define $U_2 = \{(x,y) \in [0,1] \times [-1,1] \mid x < 0.5\} \cup \{(x,y) \in [0,1] \times [-1,1] \mid x > 0.5\}$ and the chart map $\phi_2: U_2 \to \mathbb{R}^2$ by
+   - For $(x,y)$ with $x < 0.5$, let $\phi_2(x,y) = (x,y)$.
+   - For $(x,y)$ with $x > 0.5$, let $\phi_2(x,y) = (x-1,-y)$.
+    This chart covers the regions near the edges of the rectangle and respects the identification of the edges.
+
+The transition map between the two charts on the overlap $U_1 \cap U_2$ is given by:
+- For $(x,y)$ with $x < 0.5$, $\phi_2 \circ \phi_1^{-1}(x,y) = (x,y)$, which is smooth.
+- For $(x,y)$ with $x > 0.5$, $\phi_2 \circ \phi_1^{-1}(x,y) = (x-1,-y)$, which is also smooth.
+
+Since both charts are homeomorphisms onto their images and the transition maps are smooth, the collection of these charts forms a smooth atlas on the Möbius strip. Thus, the Möbius strip is a smooth manifold.
+
 # Exercise 4
 The stereographic projection maps on $S^n$ are given by
 

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -36,8 +36,8 @@ The Möbius strip is the quotient space of the rectangle $[0,1] \times [-1,1]$ b
 
 To define a smooth structure on the Möbius strip, we can use the following charts:
 
-1. **Chart 1**: Define $U_1 = (0,1) \times (-1,1)$ and the chart map $\phi_1: U_1 \to \mathbb{R}^2$ by $\phi_1(x,y) = (x,y)$. This chart covers the interior of the rectangle and is clearly a homeomorphism onto its image.
-2. **Chart 2**: Define $U_2 = \{(x,y) \in [0,1] \times [-1,1] \mid x < 0.5\} \cup \{(x,y) \in [0,1] \times [-1,1] \mid x > 0.5\}$ and the chart map $\phi_2: U_2 \to \mathbb{R}^2$ by
+1. Define $U_1 = (0,1) \times (-1,1)$ and the chart map $\phi_1: U_1 \to \mathbb{R}^2$ by $\phi_1(x,y) = (x,y)$. This chart covers the interior of the rectangle and is clearly a homeomorphism onto its image.
+2. Define $`U_2 = \{(x,y) \in [0,1] \times [-1,1] \mid x < 0.5\} \cup \{(x,y) \in [0,1] \times [-1,1] \mid x > 0.5\}`$ and the chart map $\phi_2: U_2 \to \mathbb{R}^2$ by
    - For $(x,y)$ with $x < 0.5$, let $\phi_2(x,y) = (x,y)$.
    - For $(x,y)$ with $x > 0.5$, let $\phi_2(x,y) = (x-1,-y)$.
    

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -147,3 +147,30 @@ In all cases, the transition maps between charts from $\mathcal{A}_H$ and $\math
 Show that $\mathbb{CP}^n$ is a compact smooth manifold. (Part of this is in [Waldron's notes](https://people.math.wisc.edu/~awaldron3/Notes/761%20notes%20final.pdf).)
 
 Proof
+
+Define $\mathbb{CP}^n$ as the set of complex lines in $\mathbb{C}^{n+1}$ with homogeneous coordinates $[z_0:\cdots:z_n]$, not all zero, modulo scalar multiplication by $\lambda\in\mathbb{C}^\times$.
+
+For $k=0,\dots,n$ set
+$`U_k=\{[z]\in\mathbb{CP}^n:\ z_k\neq 0\},`$
+
+$\iota_k:U_k\to\mathbb{C}^n,$
+
+$\iota_k([z])=(z_0/z_k,\ldots,z_{k-1}/z_k,z_{k+1}/z_k,\ldots,z_n/z_k).$
+
+Each $\iota_k$ is a homeomorphism with inverse
+
+$\iota_k^{-1}(w_0,\ldots,w_{n-1})=[w_0:\cdots:w_{k-1}:1:w_k:\cdots:w_{n-1}],$
+
+so $\{(U_k,\iota_k)\}_{k=0}^n$ is an atlas with model space $\mathbb{C}^n\cong\mathbb{R}^{2n}$.
+
+On overlaps $U_j\cap U_k$ the transition maps are holomorphic (hence smooth). Writing $w=(w_0,\ldots,w_{n-1})=\iota_k([z])$:
+- If $j<k$, then $z_j=w_j$ and
+$(\iota_j\circ\iota_k^{-1})(w)=\Big(\tfrac{w_0}{w_j},\ldots,\tfrac{w_{j-1}}{w_j},\tfrac{1}{w_j},\tfrac{w_{j+1}}{w_j},\ldots,\tfrac{w_{k-1}}{w_j},\tfrac{w_k}{w_j},\ldots,\tfrac{w_{n-1}}{w_j}\Big).$
+- If $j>k$, then $z_j=w_{j-1}$ and
+$(\iota_j\circ\iota_k^{-1})(w)=\Big(\tfrac{w_0}{w_{j-1}},\ldots,\tfrac{w_{k-1}}{w_{j-1}},\tfrac{1}{w_{j-1}},\tfrac{w_k}{w_{j-1}},\ldots,\tfrac{w_{j-2}}{w_{j-1}},\tfrac{w_j}{w_{j-1}},\ldots,\tfrac{w_{n-1}}{w_{j-1}}\Big)$.
+
+In each case the denominator is nonzero on $U_j\cap U_k$, so these maps are rational holomorphic functions.
+
+Thus $`\{\iota_k\}`$ defines the default smooth (indeed complex) structure on $\mathbb{CP}^n$, making it a $2n$-dimensional smooth manifold.
+
+Compactness: consider the Hopf fibration $\pi:S^{2n+1}\subset\mathbb{C}^{n+1}\to\mathbb{CP}^n$, $\pi(z)=[z]$. The fiber is $S^1$, the map is continuous and surjective, and $S^{2n+1}$ is compact. Hence $\mathbb{CP}^n\cong S^{2n+1}/S^1$ is compact (and Hausdorff). Therefore $\mathbb{CP}^n$ is a compact smooth manifold.

--- a/HW 2 Smooth manifolds.md
+++ b/HW 2 Smooth manifolds.md
@@ -40,6 +40,7 @@ To define a smooth structure on the Möbius strip, we can use the following char
 2. **Chart 2**: Define $U_2 = \{(x,y) \in [0,1] \times [-1,1] \mid x < 0.5\} \cup \{(x,y) \in [0,1] \times [-1,1] \mid x > 0.5\}$ and the chart map $\phi_2: U_2 \to \mathbb{R}^2$ by
    - For $(x,y)$ with $x < 0.5$, let $\phi_2(x,y) = (x,y)$.
    - For $(x,y)$ with $x > 0.5$, let $\phi_2(x,y) = (x-1,-y)$.
+   
     This chart covers the regions near the edges of the rectangle and respects the identification of the edges.
 
 The transition map between the two charts on the overlap $U_1 \cap U_2$ is given by:


### PR DESCRIPTION
This pull request adds detailed proofs and constructions for the smooth manifold structures on the Möbius strip and complex projective space $\mathbb{CP}^n$ in the homework document. The main improvements are the explicit construction of smooth atlases and verification of smoothness and compactness properties.

**Additions of smooth structure proofs:**

* Möbius strip: Added a step-by-step construction of a smooth atlas for the Möbius strip, including explicit charts, transition maps, and verification that the transition maps are smooth.
* Complex projective space $\mathbb{CP}^n$: Provided a detailed construction of standard charts, explicit formulas for transition maps, and a proof of smoothness and compactness for $\mathbb{CP}^n$ as a $2n$-dimensional smooth manifold.