### PR TITLE
Fix mapping definition in cyclic group proof

### DIFF
--- a/HW 3 from Hungerford's Algebra.md
+++ b/HW 3 from Hungerford's Algebra.md
@@ -4,7 +4,7 @@ The cyclic group of order 6 is the group defined by generators $a, b$ and relati
 
 Proof
 
-Let $C_6=\langle x|x^6=e\rangle$ be the cyclic group of order 6. Define a map $f\colon C_6\to G$ by $f(x)=ab^{-1}$ and extend it to a homomorphism. Since $f(x)^6=(ab^{-1})^6=e$, $f$ is well-defined.
+Let $C_6=\langle x|x^6=e\rangle$ be the cyclic group of order 6. Define a map $f\colon C_6\to G$ by $f(x)=ab^{-1}$ and extend it to a homomorphism. Since $ab=ba$ (from the given relations), we have $(ab^{-1})^6=a^6(b^{-1})^6=(a^2)^3(b^3)^{-2}=e$, so $f$ is well-defined.
 
 Define a map $g\colon G\to C_6$ by $g(a)=x^3,g(b)=x^2$ and extend it to a homomorphism. Since $g(a)^2=g(b)^3=g(a)^{-1}g(b)^{-1}g(a)g(b)=e$, $g$ is well-defined.
 

--- a/HW 3 from Hungerford's Algebra.md
+++ b/HW 3 from Hungerford's Algebra.md
@@ -10,7 +10,8 @@ Define a map $g\colon G\to C_6$ by $g(a)=x^3,g(b)=x^2$ and extend it to a homomo
 
 To see that $f,g$ are inverses of each other, it suffices to check on generators:
 - $g(f(x))=g(ab^{-1})=g(a)g(b)^{-1}=x^3x^{-2}=x$
-- $f(g(a))=f(x^3)=(ab^{-1})^3=a$, $f(g(b))=f(x^2)=(ab^{-1})^2=b$
+- $f(g(a))=f(x^3)=(ab^{-1})^3=a^3(b^{-1})^3=(a^2)a(b^3)^{-1}=a$
+- $f(g(b))=f(x^2)=(ab^{-1})^2=a^2(b^{-1})^2=(b^{-1})^2=(b^2)^2=b^4=b$
 
 Thus $G\cong C_6$.
 

--- a/HW 3 from Hungerford's Algebra.md
+++ b/HW 3 from Hungerford's Algebra.md
@@ -4,13 +4,13 @@ The cyclic group of order 6 is the group defined by generators $a, b$ and relati
 
 Proof
 
-Let $C_6=\langle x|x^6=e\rangle$ be the cyclic group of order 6. Define a map $f\colon C_6\to G$ by $f(x)=ab$ and extend it to a homomorphism. Since $(ab)^6=a^2=b^3=e$, $f$ is well-defined.
+Let $C_6=\langle x|x^6=e\rangle$ be the cyclic group of order 6. Define a map $f\colon C_6\to G$ by $f(x)=ab^{-1}$ and extend it to a homomorphism. Since $f(x)^6=(ab^{-1})^6=e$, $f$ is well-defined.
 
 Define a map $g\colon G\to C_6$ by $g(a)=x^3,g(b)=x^2$ and extend it to a homomorphism. Since $g(a)^2=g(b)^3=g(a)^{-1}g(b)^{-1}g(a)g(b)=e$, $g$ is well-defined.
 
 To see that $f,g$ are inverses of each other, it suffices to check on generators:
-- $g(f(x))=g(ab)=g(a)g(b)=x^3x^2=x$
-- $f(g(a))=f(x^3)=(ab)^3=a$, $f(g(b))=f(x^2)=(ab)^2=b$
+- $g(f(x))=g(ab^{-1})=g(a)g(b)^{-1}=x^3x^{-2}=x$
+- $f(g(a))=f(x^3)=(ab^{-1})^3=a$, $f(g(b))=f(x^2)=(ab^{-1})^2=b$
 
 Thus $G\cong C_6$.
 


### PR DESCRIPTION
This pull request updates the proof showing an isomorphism between a group defined by generators $a, b$ and the cyclic group of order 6. The main change is correcting the definitions of the homomorphisms $f$ and $g$ to use $ab^{-1}$ instead of $ab$, along with corresponding updates in the calculations and justifications.

Corrections to homomorphism definitions and proof steps:

* Changed the definition of the map $f$ from $f(x) = ab$ to $f(x) = ab^{-1}$, and updated the justification for $f$ being well-defined accordingly.
* Updated the verification steps for $f$ and $g$ being inverses to match the new definitions, ensuring correctness of the isomorphism proof.