### PR TITLE
Enhance proof on homotopy classes in fundamental group

### DIFF
--- a/HW 2 Hatcher Chapter 1.md
+++ b/HW 2 Hatcher Chapter 1.md
@@ -76,15 +76,15 @@ We can regard $\pi_1(X, x_0)$ as the set of basepoint-preserving homotopy classe
 
 Proof
 
-$\pi_1(X,x_0)$ is the set of endpoint-preserving homotopy classes of loops in $X$ based at $x_0$. A loop is a path $f\colon I \to X$ with $f(0)=f(1)$. The question states we can regard $\pi_1(X, x_0)$ as the set of basepoint-preserving homotopy classes of maps $(S^1, s_0) \to (X, x_0).
+$\pi_1(X,x_0)$ is the set of endpoint-preserving homotopy classes of loops in $X$ based at $x_0$. A loop is a path $f\colon I \to X$ with $f(0)=f(1)$. The question states we can regard $\pi_1(X, x_0)$ as the set of basepoint-preserving homotopy classes of maps $(S^1, s_0) \to (X, x_0)$.
 
-Note that $I/(0 \sim 1) \cong S^1$ as a topological space. By the definition of a quotient map, if you have a continuous map $f: I \to X$ such that $f(0)=f(1)=x_0$, this factors through the above quotient map, giving a map $f': I/(0 \sim 1) \to X$, with $f'([0]) = x_0$.
+Note that $I/(0 \sim 1) \cong S^1$ is a homeomorphism. If you have a continuous map $f\colon I \to X$ such that $f(0)=f(1)=x_0$, this factors through the above quotient map, giving a map $f'\colon I/(0 \sim 1) \to X$, with $f'([0]) = x_0$.
 
-Conversely, given a based map $f: (S^1, s_0) \to (X,x_0)$, you can obtain a loop $f': I \to X$ with $f'(0)=f'(1)=x_0$ by pre-composing $f$ with the canonical quotient map $I \to I/(0 \sim 1) \cong S^1$.
+Conversely, given a based map $f\colon(S^1, s_0) \to (X,x_0)$, you can obtain a loop $f'\colon I \to X$ with $f'(0)=f'(1)=x_0$ by pre-composing $f$ with the canonical quotient map $I \to I/(0 \sim 1) \cong S^1$.
 
 If $X$ is path-connected, for any map $g\colon S^1 \to X$, we can choose a point $s_0 \in S^1$ and let $x_0 = g(s_0)$. Since $X$ is path-connected, there exists a path $\gamma\colon I \to X$ such that $\gamma(0) = x_0$ and $\gamma(1) = g(s_0)$. We can then define a new map $f\colon S^1 \to X$ by setting $f(s) = \beta_\gamma(s)$, where $\beta_\gamma$ is a loop based at $x_0$ that traverses the path $\gamma$ and then follows the image of $g$ then returns along $\gamma^{-1}$. This shows that every homotopy class in $[S^1, X]$ has a representative in $\pi_1(X, x_0)$, hence $\Phi$ is onto.
 
-Suppose $\Phi([f]) = \Phi([g])$. This means that the maps $f$ and $g$ are homotopic as maps from $S^1$ to $X$. Let $H\colon S^1 \times I \to X$ be a homotopy between $f$ and $g$. Since $X$ is path-connected, we can choose a path $\gamma\colon I \to X$ such that $\gamma(0) = x_0$ and $\gamma(1) = g(s_0)$. We can then construct a loop based at $x_0$ by concatenating the path $\gamma$, the loop $g$, and the inverse path $\gamma^{-1}$. This shows that $[f]$ and $[g]$ are conjugate in $\pi_1(X, x_0)$.
+Suppose $\Phi([f]) = \Phi([g])$. This means that the maps $f$ and $g$ are homotopic as maps from $S^1$ to $X$. Let $H\colon S^1 \times I \to X$ be a free homotopy between $f$ and $g$. The path that induces the conjugacy is precisely the path traced by the basepoint during the homotopy, $γ(t) = H(s_0, t)$.
 
 ## Exercise 11
 If $X_0$ is the path-component of a space $X$ containing the basepoint $x_0$, show that the inclusion $X_0 \hookrightarrow X$ induces an isomorphism $\pi_1(X_0, x_0) \to \pi_1(X, x_0)$.


### PR DESCRIPTION
Expanded the proof regarding the relationship between homotopy classes and the fundamental group, including details on constructing loops and establishing conjugacy.