### PR TITLE
Clarify proof of di_p's injectivity and surjectivity

### DIFF
--- a/HW 4 tangent spaces.md
+++ b/HW 4 tangent spaces.md
@@ -126,31 +126,30 @@ Since $U$ is an open subset of $M$, there exists a chart $(V, \phi)$ of $M$ such
 
 Let $i: U \to M$ be the inclusion map.
 
-To show that the differential $di_p: T_p U \to T_p M$ is injective, we note that if $u \in T_p U$ and $di_p(u) = 0$, then for any smooth function $f \in C^\infty(U)$, take a smooth extension $\tilde{f} \in C^\infty(M)$. We have:
+- To show that the differential $di_p: T_p U \to T_p M$ is injective, we note that if $u \in T_p U$ and $di_p(u) = 0$, then for any smooth function $f \in C^\infty(U)$, take a smooth extension $\tilde{f} \in C^\infty(M)$. We have:
 
-$u(f) = u(\tilde{f} \circ i) = (di_p(u))(\tilde{f})$. Since $di_p(u)=0$, it follows that $u(f)=0.
+  $u(f) = u(\tilde{f} \circ i) = (di_p(u))(\tilde{f})$. Since $di_p(u)=0$, it follows that $u(f)=0$.
 
-Thus, as this holds for any $f \in C^\infty(U)$, $u=0$, proving injectivity.
+  Thus, as this holds for any $f \in C^\infty(U)$, $u=0$, proving injectivity.
+- To show that $di_p$ is surjective, let $v \in T_p M$ be an arbitrary derivation. We must construct a derivation $u \in T_p U$ such that $di_p(u) = v$.
 
-To show that $di_p$ is surjective, let $v \in T_p M$ be an arbitrary derivation. We must construct a derivation $u \in T_p U$ such that $di_p(u) = v$.
+  Define a map $u: C^\infty(U) \to \mathbb{R}$. For any smooth function $g \in C^\infty(U)$, by the Extension Lemma for Smooth Functions, there exists a smooth function $\tilde{g} \in C^\infty(M)$ that extends $g$ (i.e., $\tilde{g}|_U = g$). We define:
 
-Let's define a map $u: C^\infty(U) \to \mathbb{R}$. For any smooth function $g \in C^\infty(U)$, by the Extension Lemma for Smooth Functions, there exists a smooth function $\tilde{g} \in C^\infty(M)$ that extends $g$ (i.e., $\tilde{g}|_U = g$). We define:
+  $u(g) := v(\tilde{g})$
 
-$u(g) := v(\tilde{g})$
+  This definition is well-defined. If $\tilde{g}_1$ and $\tilde{g}_2$ are two different extensions of $g$, their difference $\tilde{g}_1 - \tilde{g}_2$ is zero on the open neighborhood $U$ of $p$. Since derivations are local operators (their value on a function depends only on the germ of the function at the point), this implies $v(\tilde{g}_1 - \tilde{g}_2) = 0$, so $v(\tilde{g}_1) = v(\tilde{g}_2)$.
 
-This definition is well-defined. If $\tilde{g}_1$ and $\tilde{g}_2$ are two different extensions of $g$, their difference $\tilde{g}_1 - \tilde{g}_2$ is zero on the open neighborhood $U$ of $p$. Since derivations are local operators (their value on a function depends only on the germ of the function at the point), this implies $v(\tilde{g}_1 - \tilde{g}_2) = 0$, so $v(\tilde{g}_1) = v(\tilde{g}_2)$.
+  The map $u$ is a derivation at $p$ on $U$ because it inherits linearity and the Leibniz property from $v$. Thus, $u \in T_p U$.
 
-The map $u$ is a derivation at $p$ on $U$ because it inherits linearity and the Leibniz property from $v$. Thus, $u \in T_p U$.
+  Finally, we check if $di_p(u) = v$. For any $f \in C^\infty(M)$:
 
-Finally, we check if $di_p(u) = v$. For any $f \in C^\infty(M)$:
+  $`di_p(u)(f) = u(f|_U)`$
 
-$`di_p(u)(f) = u(f|_U)`$
+  By our definition of $u$, this is equal to $v(\widetilde{f|_U})$, where $\widetilde{f|_U}$ is any smooth extension of $f|_U$. We can choose $f$ itself as the extension. Therefore:
 
-By our definition of $u$, this is equal to $v(\widetilde{f|_U})$, where $\widetilde{f|_U}$ is any smooth extension of $f|_U$. We can choose $f$ itself as the extension. Therefore:
+  $`di_p(u)(f) = v(f)`$
 
-$`di_p(u)(f) = v(f)`$
-
-Since this holds for all $f \in C^\infty(M)$, we have $di_p(u) = v$. Thus, $di_p$ is surjective.
+  Since this holds for all $f \in C^\infty(M)$, we have $di_p(u) = v$. Thus, $di_p$ is surjective.
 
 Since $di_p$ is both injective and surjective, it is an isomorphism. To show that this isomorphism is canonical, we note that it does not depend on the choice of chart or extension, as the construction is based solely on the properties of derivations and the inclusion map.
 


### PR DESCRIPTION
Refactor the proof of the injectivity and surjectivity of the differential map di_p, clarifying definitions and ensuring consistent notation.