### PR TITLE
Add proof for absence of smooth submersion from compact manifold

### DIFF
--- a/HW 5 Local diffeomorphisms, immersions, submersions.md
+++ b/HW 5 Local diffeomorphisms, immersions, submersions.md
@@ -3,7 +3,7 @@ Let $M$ be a nonempty smooth compact manifold. Show that there is no smooth subm
 
 Proof
 
-The image of a compact manifold under a smooth map is also compact. Since $\mathbb{R}$ is not compact, the image of $M$ under $F$ cannot be all of $\mathbb{R}$. Therefore, the differential $dF_p$ cannot be surjective for all $p \in M$, which contradicts the assumption that $F$ is a submersion.
+Since $M$ is a compact manifold and $F$ is a smooth map, its image $F(M)$ is a compact subset of $\mathbb{R}$. As $M$ is non-empty, $F(M)$ must attain a maximum value at some point $p \in M$. At this maximum, $p$ is a critical point of $F$, meaning its differential $dF_p$ is not surjective. This contradicts the definition of a submersion, which requires $dF_p$ to be surjective for all $p \in M$.
 
 # 2
 Let $`M=\mathrm{SL}(n, \mathbb{R}))=\{A \in \mathrm{GL}(n, \mathbb{R}) \mid \det(A)=1\}`$. Show that $M$ is a smooth manifold.


### PR DESCRIPTION
Added a proof demonstrating that there is no smooth submersion from a compact manifold to the real numbers, based on the properties of compactness.